### PR TITLE
Add POST /sites route for site registration

### DIFF
--- a/ai-licensing/brownstone-api/routes/sites.js
+++ b/ai-licensing/brownstone-api/routes/sites.js
@@ -1,0 +1,34 @@
+// sites.js
+
+const express = require("express");
+const router = express.Router();
+const crypto = require("crypto");
+const Site = require("../models/Site");
+
+// POST /sites — register a new site and receive an API key
+router.post("/", async (req, res) => {
+  const { name, license, enforcementEnabled, blockedAIs } = req.body;
+
+  if (!name) return res.status(400).json({ error: "name is required" });
+
+  const apiKey = crypto.randomBytes(24).toString("hex");
+
+  const site = await Site.create({
+    name,
+    apiKey,
+    license: license || { model: "free", rate: null },
+    enforcementEnabled: enforcementEnabled ?? false,
+    blockedAIs: blockedAIs || [],
+  });
+
+  res.status(201).json({
+    id: site._id,
+    name: site.name,
+    apiKey: site.apiKey,
+    license: site.license,
+    enforcementEnabled: site.enforcementEnabled,
+    blockedAIs: site.blockedAIs,
+  });
+});
+
+module.exports = router;

--- a/ai-licensing/brownstone-api/server.js
+++ b/ai-licensing/brownstone-api/server.js
@@ -7,6 +7,7 @@ const cors = require("cors");
 
 const logRoute = require("./routes/log");
 const checkRoute = require("./routes/check");
+const sitesRoute = require("./routes/sites");
 
 const app = express();
 
@@ -19,6 +20,7 @@ mongoose.connect(process.env.MONGO_URI)
 
 app.use("/log", logRoute);
 app.use("/check", checkRoute);
+app.use("/sites", sitesRoute);
 
 app.listen(4000, () => {
   console.log("Brownstone API running on port 4000");


### PR DESCRIPTION
  Generates a unique API key via crypto.randomBytes and persists the new site to MongoDB with
  sensible defaults (free license, enforcement disabled, no blocked AIs).