### PR TITLE
Refactor license handling to use structured schema in Site model

### DIFF
--- a/ai-licensing/brownstone-api/models/Site.js
+++ b/ai-licensing/brownstone-api/models/Site.js
@@ -6,8 +6,9 @@ const siteSchema = new mongoose.Schema({
   name: String,
   apiKey: String,
   license: {
-    model: String, // free | paid
-    rate: String,
+    model: String,      // free | paid
+    rate: String,       // e.g. "$0.001-per-1000-tokens"
+    permission: String, // allowed | restricted | blocked
   },
   enforcementEnabled: Boolean,
   blockedAIs: [String],

--- a/ai-licensing/brownstone-middleware/src/injectMetadata.js
+++ b/ai-licensing/brownstone-middleware/src/injectMetadata.js
@@ -5,7 +5,15 @@ function injectMetadata(res, licenseOption) {
 
   res.send = function (body) {
     if (typeof body === "string" && body.includes("</head>")) {
-      const metaTag = `<meta name="ai-usage" content="${licenseOption.license || "allowed"}">`;
+      const license = licenseOption.license || {};
+      const content = [
+        license.model || "free",
+        license.rate || null,
+        license.permission || "allowed",
+      ]
+        .filter(Boolean)
+        .join("|");
+      const metaTag = `<meta name="ai-usage" content="${content}">`;
       body = body.replace("</head>", `${metaTag}</head>`);
     }
     return originalSend.call(this, body);

--- a/ai-licensing/brownstone-test-site/server.js
+++ b/ai-licensing/brownstone-test-site/server.js
@@ -8,7 +8,7 @@ app.use(
     apiKey: "brownstone-test-key-abc123",
     metering: "true",
     enforcement: "true",
-    license: "paid|$0.001-per-1000-tokens|allowed",
+    license: { model: "paid", rate: "$0.001-per-1000-tokens", permission: "allowed" },
   }),
 );
 


### PR DESCRIPTION
  Added permission field to Site model and updated injectMetadata to build the meta tag content
  from a structured license object instead of a raw string