### PR TITLE
Add tab navigation and usage view to dashboard

### DIFF
--- a/ai-licensing/dashboard/src/App.css
+++ b/ai-licensing/dashboard/src/App.css
@@ -13,7 +13,7 @@
   border-radius: 12px;
   padding: 2rem;
   width: 100%;
-  max-width: 520px;
+  max-width: 780px;
 }
 
 h1 {
@@ -111,6 +111,85 @@ button[type="submit"]:hover:not(:disabled) {
 button[type="submit"]:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+/* Tabs */
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.75rem;
+  border-bottom: 1px solid #333;
+  padding-bottom: 0.75rem;
+}
+
+.tab {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 0.9rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.2s, background 0.2s;
+}
+
+.tab:hover {
+  color: #ccc;
+  background: #2a2a2a;
+}
+
+.tab.active {
+  color: #fff;
+  background: #2a2a2a;
+}
+
+/* Secondary button */
+.btn-secondary {
+  width: 100%;
+  padding: 0.65rem;
+  font-size: 0.95rem;
+  background: #2a2a2a;
+  color: #ccc;
+  border: 1px solid #444;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.btn-secondary:hover {
+  border-color: #646cff;
+}
+
+/* Usage results */
+.usage-results {
+  margin-top: 1.5rem;
+}
+
+.usage-header {
+  font-size: 0.9rem;
+  color: #aaa;
+  margin-bottom: 0.75rem;
+}
+
+.usage-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.usage-table th {
+  text-align: left;
+  color: #888;
+  font-weight: 500;
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid #333;
+}
+
+.usage-table td {
+  padding: 0.45rem 0.5rem;
+  border-bottom: 1px solid #2a2a2a;
+  color: #ccc;
+  word-break: break-all;
 }
 
 /* Success card */

--- a/ai-licensing/dashboard/src/App.jsx
+++ b/ai-licensing/dashboard/src/App.jsx
@@ -6,6 +6,33 @@ const API_URL = "http://localhost:4000";
 const AI_OPTIONS = ["ChatGPT", "Claude", "BingAI", "Perplexity", "Gemini"];
 
 function App() {
+  const [view, setView] = useState("register");
+
+  return (
+    <div className="container">
+      <div className="card">
+        <h1>Brownstone</h1>
+        <nav className="tabs">
+          <button
+            className={view === "register" ? "tab active" : "tab"}
+            onClick={() => setView("register")}
+          >
+            Register site
+          </button>
+          <button
+            className={view === "usage" ? "tab active" : "tab"}
+            onClick={() => setView("usage")}
+          >
+            View usage
+          </button>
+        </nav>
+        {view === "register" ? <RegisterView /> : <UsageView />}
+      </div>
+    </div>
+  );
+}
+
+function RegisterView() {
   const [form, setForm] = useState({
     name: "",
     licenseModel: "free",
@@ -63,134 +90,209 @@ function App() {
     }
   }
 
-  function handleReset() {
-    setSite(null);
-    setError(null);
-    setForm({
-      name: "",
-      licenseModel: "free",
-      rate: "",
-      permission: "allowed",
-      enforcementEnabled: false,
-      blockedAIs: [],
-    });
-  }
-
   if (site) {
     return (
-      <div className="container">
-        <div className="card success-card">
-          <h2>Site registered</h2>
-          <div className="api-key-box">
-            <p className="label">API Key</p>
-            <code>{site.apiKey}</code>
-            <p className="hint">Copy this — it won't be shown again.</p>
-          </div>
-          <div className="site-details">
-            <Row label="Site ID" value={site.id} />
-            <Row label="Name" value={site.name} />
-            <Row label="License" value={`${site.license.model} / ${site.license.permission}`} />
-            {site.license.rate && <Row label="Rate" value={site.license.rate} />}
-            <Row label="Enforcement" value={site.enforcementEnabled ? "Enabled" : "Disabled"} />
-            {site.blockedAIs.length > 0 && (
-              <Row label="Blocked AIs" value={site.blockedAIs.join(", ")} />
-            )}
-          </div>
-          <button onClick={handleReset}>Register another site</button>
+      <>
+        <div className="api-key-box">
+          <p className="label">API Key</p>
+          <code>{site.apiKey}</code>
+          <p className="hint">Copy this — it won't be shown again.</p>
         </div>
-      </div>
+        <div className="site-details">
+          <Row label="Site ID" value={site.id} />
+          <Row label="Name" value={site.name} />
+          <Row label="License" value={`${site.license.model} / ${site.license.permission}`} />
+          {site.license.rate && <Row label="Rate" value={site.license.rate} />}
+          <Row label="Enforcement" value={site.enforcementEnabled ? "Enabled" : "Disabled"} />
+          {site.blockedAIs.length > 0 && (
+            <Row label="Blocked AIs" value={site.blockedAIs.join(", ")} />
+          )}
+        </div>
+        <button className="btn-secondary" onClick={() => setSite(null)}>
+          Register another site
+        </button>
+      </>
     );
   }
 
   return (
-    <div className="container">
-      <div className="card">
-        <h1>Brownstone</h1>
-        <p className="subtitle">Register a site to start tracking AI access.</p>
+    <>
+      <p className="subtitle">Register a site to start tracking AI access.</p>
+      {error && <p className="error">{error}</p>}
+      <form onSubmit={handleSubmit}>
+        <div className="field">
+          <label htmlFor="name">Site name</label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            placeholder="my-app"
+            value={form.name}
+            onChange={handleChange}
+            required
+          />
+        </div>
 
-        {error && <p className="error">{error}</p>}
-
-        <form onSubmit={handleSubmit}>
+        <div className="field-row">
           <div className="field">
-            <label htmlFor="name">Site name</label>
+            <label htmlFor="licenseModel">License model</label>
+            <select id="licenseModel" name="licenseModel" value={form.licenseModel} onChange={handleChange}>
+              <option value="free">Free</option>
+              <option value="paid">Paid</option>
+            </select>
+          </div>
+          <div className="field">
+            <label htmlFor="permission">Permission</label>
+            <select id="permission" name="permission" value={form.permission} onChange={handleChange}>
+              <option value="allowed">Allowed</option>
+              <option value="restricted">Restricted</option>
+              <option value="blocked">Blocked</option>
+            </select>
+          </div>
+        </div>
+
+        {form.licenseModel === "paid" && (
+          <div className="field">
+            <label htmlFor="rate">Rate</label>
             <input
-              id="name"
-              name="name"
+              id="rate"
+              name="rate"
               type="text"
-              placeholder="my-app"
-              value={form.name}
+              placeholder="$0.001-per-1000-tokens"
+              value={form.rate}
               onChange={handleChange}
-              required
             />
           </div>
+        )}
 
-          <div className="field-row">
-            <div className="field">
-              <label htmlFor="licenseModel">License model</label>
-              <select id="licenseModel" name="licenseModel" value={form.licenseModel} onChange={handleChange}>
-                <option value="free">Free</option>
-                <option value="paid">Paid</option>
-              </select>
-            </div>
-
-            <div className="field">
-              <label htmlFor="permission">Permission</label>
-              <select id="permission" name="permission" value={form.permission} onChange={handleChange}>
-                <option value="allowed">Allowed</option>
-                <option value="restricted">Restricted</option>
-                <option value="blocked">Blocked</option>
-              </select>
-            </div>
+        <div className="field">
+          <label>Block specific AIs</label>
+          <div className="checkbox-group">
+            {AI_OPTIONS.map((ai) => (
+              <label key={ai} className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={form.blockedAIs.includes(ai)}
+                  onChange={() => toggleBlockedAI(ai)}
+                />
+                {ai}
+              </label>
+            ))}
           </div>
+        </div>
 
-          {form.licenseModel === "paid" && (
-            <div className="field">
-              <label htmlFor="rate">Rate</label>
-              <input
-                id="rate"
-                name="rate"
-                type="text"
-                placeholder="$0.001-per-1000-tokens"
-                value={form.rate}
-                onChange={handleChange}
-              />
-            </div>
+        <div className="field checkbox-field">
+          <label className="checkbox-label">
+            <input
+              type="checkbox"
+              name="enforcementEnabled"
+              checked={form.enforcementEnabled}
+              onChange={handleChange}
+            />
+            Enable enforcement
+          </label>
+        </div>
+
+        <button type="submit" disabled={loading}>
+          {loading ? "Registering..." : "Register site"}
+        </button>
+      </form>
+    </>
+  );
+}
+
+function UsageView() {
+  const [siteId, setSiteId] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+    setResult(null);
+    setLoading(true);
+
+    try {
+      const res = await fetch(`${API_URL}/sites/${siteId}/usage`, {
+        headers: { "x-api-key": apiKey },
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to fetch usage");
+      setResult(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <p className="subtitle">Look up AI access logs for a registered site.</p>
+      {error && <p className="error">{error}</p>}
+      <form onSubmit={handleSubmit}>
+        <div className="field">
+          <label htmlFor="siteId">Site ID</label>
+          <input
+            id="siteId"
+            type="text"
+            placeholder="64f3a..."
+            value={siteId}
+            onChange={(e) => setSiteId(e.target.value)}
+            required
+          />
+        </div>
+        <div className="field">
+          <label htmlFor="apiKey">API Key</label>
+          <input
+            id="apiKey"
+            type="text"
+            placeholder="your-api-key"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            required
+          />
+        </div>
+        <button type="submit" disabled={loading}>
+          {loading ? "Loading..." : "Fetch usage"}
+        </button>
+      </form>
+
+      {result && (
+        <div className="usage-results">
+          <p className="usage-header">
+            <strong>{result.name}</strong> — {result.usage.length} request{result.usage.length !== 1 ? "s" : ""}
+          </p>
+          {result.usage.length === 0 ? (
+            <p className="hint">No AI access logged yet.</p>
+          ) : (
+            <table className="usage-table">
+              <thead>
+                <tr>
+                  <th>AI</th>
+                  <th>Path</th>
+                  <th>IP</th>
+                  <th>Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.usage.map((log) => (
+                  <tr key={log._id}>
+                    <td>{log.aiProvider}</td>
+                    <td>{log.path}</td>
+                    <td>{log.ip}</td>
+                    <td>{new Date(log.timestamp).toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           )}
-
-          <div className="field">
-            <label>Block specific AIs</label>
-            <div className="checkbox-group">
-              {AI_OPTIONS.map((ai) => (
-                <label key={ai} className="checkbox-label">
-                  <input
-                    type="checkbox"
-                    checked={form.blockedAIs.includes(ai)}
-                    onChange={() => toggleBlockedAI(ai)}
-                  />
-                  {ai}
-                </label>
-              ))}
-            </div>
-          </div>
-
-          <div className="field checkbox-field">
-            <label className="checkbox-label">
-              <input
-                type="checkbox"
-                name="enforcementEnabled"
-                checked={form.enforcementEnabled}
-                onChange={handleChange}
-              />
-              Enable enforcement
-            </label>
-          </div>
-
-          <button type="submit" disabled={loading}>
-            {loading ? "Registering..." : "Register site"}
-          </button>
-        </form>
-      </div>
-    </div>
+        </div>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
  Adds a two-tab layout with a usage lookup view that fetches and displays AI access logs by site
  ID and API key.