### PR TITLE
Add webhook support for AI access events and update Site model

### DIFF
--- a/ai-licensing/brownstone-api/models/Site.js
+++ b/ai-licensing/brownstone-api/models/Site.js
@@ -12,6 +12,7 @@ const siteSchema = new mongoose.Schema({
   },
   enforcementEnabled: Boolean,
   blockedAIs: [String],
+  webhookUrl: String,
 });
 
 module.exports = mongoose.model("Site", siteSchema);

--- a/ai-licensing/brownstone-api/routes/log.js
+++ b/ai-licensing/brownstone-api/routes/log.js
@@ -4,6 +4,7 @@ const express = require("express");
 const router = express.Router();
 const Site = require("../models/Site");
 const Usage = require("../models/Usage");
+const fireWebhook = require("../utils/fireWebhook");
 
 router.post("/", async (req, res) => {
   const apiKey = req.headers["x-api-key"];
@@ -12,12 +13,24 @@ router.post("/", async (req, res) => {
   const site = await Site.findOne({ apiKey });
   if (!site) return res.status(401).json({ error: "Invalid API key" });
 
-  await Usage.create({
+  const usage = await Usage.create({
     siteId: site._id,
     aiProvider: ai,
     path,
     ip,
   });
+
+  if (site.webhookUrl) {
+    fireWebhook(site.webhookUrl, {
+      event: "ai.access",
+      siteId: site._id,
+      siteName: site.name,
+      aiProvider: ai,
+      path,
+      ip,
+      timestamp: usage.timestamp,
+    });
+  }
 
   res.json({ success: true });
 });

--- a/ai-licensing/brownstone-api/routes/sites.js
+++ b/ai-licensing/brownstone-api/routes/sites.js
@@ -7,7 +7,7 @@ const Site = require("../models/Site");
 
 // POST /sites — register a new site and receive an API key
 router.post("/", async (req, res) => {
-  const { name, license, enforcementEnabled, blockedAIs } = req.body;
+  const { name, license, enforcementEnabled, blockedAIs, webhookUrl } = req.body;
 
   if (!name) return res.status(400).json({ error: "name is required" });
 
@@ -19,6 +19,7 @@ router.post("/", async (req, res) => {
     license: license || { model: "free", rate: null },
     enforcementEnabled: enforcementEnabled ?? false,
     blockedAIs: blockedAIs || [],
+    webhookUrl: webhookUrl || null,
   });
 
   res.status(201).json({
@@ -28,6 +29,7 @@ router.post("/", async (req, res) => {
     license: site.license,
     enforcementEnabled: site.enforcementEnabled,
     blockedAIs: site.blockedAIs,
+    webhookUrl: site.webhookUrl,
   });
 });
 

--- a/ai-licensing/brownstone-api/utils/fireWebhook.js
+++ b/ai-licensing/brownstone-api/utils/fireWebhook.js
@@ -1,0 +1,15 @@
+// fireWebhook.js
+
+async function fireWebhook(url, payload) {
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    console.error(`Webhook delivery failed for ${url}:`, err.message);
+  }
+}
+
+module.exports = fireWebhook;


### PR DESCRIPTION
  Fires a POST to the site's webhookUrl after each AI hit is logged. Added webhookUrl field to
  Site model and exposed it through POST /sites.